### PR TITLE
페이지에 모달 적용

### DIFF
--- a/src/components/modal/create-group-modal .tsx
+++ b/src/components/modal/create-group-modal .tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import Modal from './modal';
+
+interface GroupModalProps {
+  children: React.ReactNode;
+}
+
+const CreateGroupModal = ({ children }: GroupModalProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpenClick = () => {
+    setIsOpen(true);
+  };
+
+  return (
+    <button onClick={handleOpenClick}>
+      {children}
+      <Modal isOpen={isOpen} onClose={() => setIsOpen(false)}>
+        그룹 생성
+        {/* 내용 작성 예정 */}
+      </Modal>
+    </button>
+  );
+};
+
+export default CreateGroupModal;

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -52,10 +52,4 @@ const S = {
     background: #ffffff;
     border-radius: 8px;
   `,
-
-  CloseButton: styled.button`
-    padding: 8px;
-    border: 1px solid #000000;
-    border-radius: 8px;
-  `,
 };

--- a/src/pages/group-home/components/meeting-notes.tsx
+++ b/src/pages/group-home/components/meeting-notes.tsx
@@ -1,3 +1,4 @@
+import ReportModal from '@components/modal/report-modal';
 import styled from 'styled-components';
 
 const NOTES_DATAS = [
@@ -51,10 +52,12 @@ const MeetingNotes = () => {
 
       <S.MeetingNotesLists>
         {NOTES_DATAS.map((note) => (
-          <S.MeetingNotesList key={note.id}>
-            <S.NoteTitle>{note.title}</S.NoteTitle>
-            <S.NoteCreatedAt>{note.createdAt}</S.NoteCreatedAt>
-          </S.MeetingNotesList>
+          <ReportModal>
+            <S.MeetingNotesList key={note.id}>
+              <S.NoteTitle>{note.title}</S.NoteTitle>
+              <S.NoteCreatedAt>{note.createdAt}</S.NoteCreatedAt>
+            </S.MeetingNotesList>
+          </ReportModal>
         ))}
       </S.MeetingNotesLists>
     </S.Container>

--- a/src/pages/group-home/components/meetings.tsx
+++ b/src/pages/group-home/components/meetings.tsx
@@ -1,3 +1,4 @@
+import MeetingModal from '@components/modal/meeting-modal';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -12,7 +13,9 @@ const Meetings = () => {
     <S.Container>
       <S.Meetings>
         <div onClick={handleMeetingClick}>회의중</div>
-        <div>회의 예정</div>
+        <MeetingModal>
+          <div>회의 예정</div>
+        </MeetingModal>
       </S.Meetings>
     </S.Container>
   );

--- a/src/pages/group-home/index.tsx
+++ b/src/pages/group-home/index.tsx
@@ -1,4 +1,6 @@
 import arrowRight from '@assets/icons/arrow-left.svg';
+import GroupModal from '@components/modal/group-modal';
+import MeetingModal from '@components/modal/meeting-modal';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import MeetingNotes from './components/meeting-notes';
@@ -16,8 +18,12 @@ const GroupHome = () => {
       <S.GroupHomeHeader>
         <S.BackButton onClick={handleBackButtonClick} />
         <S.ManageButtons>
-          <button>그룹 관리</button>
-          <button>회의 생성</button>
+          <GroupModal>
+            <div>그룹 관리</div>
+          </GroupModal>
+          <MeetingModal>
+            <div>회의 생성</div>
+          </MeetingModal>
         </S.ManageButtons>
       </S.GroupHomeHeader>
 

--- a/src/pages/lobby/components/dropdown-button.tsx
+++ b/src/pages/lobby/components/dropdown-button.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode, useState, useRef } from 'react';
+import MeetingModal from '@components/modal/meeting-modal';
 import styled from 'styled-components';
 import QuickButton from './quick-button';
 import useOutsideClick from '../hooks/use-outside-click';
@@ -28,9 +29,11 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({ children }) => {
       <QuickButton onClick={handleButtonClick}>{children}</QuickButton>
       <S.DropdownBox $isOpen={isDropdownOpen}>
         {groupList.map((item) => (
-          <S.DropdownList key={item} onClick={handleDropdownClose}>
-            {item}
-          </S.DropdownList>
+          <MeetingModal>
+            <S.DropdownList key={item} onClick={handleDropdownClose}>
+              {item}
+            </S.DropdownList>
+          </MeetingModal>
         ))}
       </S.DropdownBox>
     </S.DropdownButtonWrapper>
@@ -42,18 +45,17 @@ const S = {
     position: relative;
   `,
   DropdownBox: styled.ul<{ $isOpen: boolean }>`
+    display: ${({ $isOpen }) => ($isOpen ? 'flex' : 'none')};
+    flex-direction: column;
     position: absolute;
     border: 1px solid black;
     border-top: none;
     border-bottom: none;
     width: 100%;
-    display: ${({ $isOpen }) => ($isOpen ? 'block' : 'none')};
   `,
   DropdownList: styled.li`
     border-bottom: 1px solid black;
     padding: 2px;
-    cursor: pointer;
-
     &:hover {
       background-color: #f0f0f0;
     }

--- a/src/pages/lobby/index.tsx
+++ b/src/pages/lobby/index.tsx
@@ -1,3 +1,4 @@
+import UserInfoModal from '@components/modal/user-info-modal';
 import styled from 'styled-components';
 import DropdownButton from './components/dropdown-button';
 import MyCalendar from './components/my-calendar';
@@ -9,7 +10,9 @@ const Lobby = () => {
     <S.LobbyPageWrapper>
       <S.QuickButtonBox>
         <DropdownButton>회의 생성</DropdownButton>
-        <QuickButton>내 정보</QuickButton>
+        <UserInfoModal>
+          <QuickButton>내 정보</QuickButton>
+        </UserInfoModal>
       </S.QuickButtonBox>
       <S.MyScheduleBox>
         <MyCalendar />

--- a/src/pages/nav-bar/index.tsx
+++ b/src/pages/nav-bar/index.tsx
@@ -1,3 +1,4 @@
+import UserInfoModal from '@components/modal/user-info-modal';
 import { device } from '@styles/breakpoints';
 import { navBarHeight } from '@styles/subsection-size';
 import styled from 'styled-components';
@@ -12,7 +13,9 @@ const NavBar = () => {
         <S.FlexRightBox>
           <S.SearchBarBox>검색</S.SearchBarBox>
           <S.AlarmBox>알림</S.AlarmBox>
-          <S.ProfileBox>프로필</S.ProfileBox>
+          <UserInfoModal>
+            <S.ProfileBox>프로필</S.ProfileBox>
+          </UserInfoModal>
         </S.FlexRightBox>
       </S.NavContainer>
     </S.NavWrap>

--- a/src/pages/side-bar/index.tsx
+++ b/src/pages/side-bar/index.tsx
@@ -1,9 +1,20 @@
+import CreateGroupModal from '@components/modal/create-group-modal ';
 import { device } from '@styles/breakpoints';
 import { navBarHeight, sideBarWidth } from '@styles/subsection-size';
 import styled from 'styled-components';
 
 const SideBar = () => {
-  return <S.SideWrap>SideBar입니다!</S.SideWrap>;
+  return (
+    <S.SideWrap>
+      SideBar입니다!
+      <S.AddGroup>
+        <p>그룹</p>
+        <CreateGroupModal>
+          <div>+</div>
+        </CreateGroupModal>
+      </S.AddGroup>
+    </S.SideWrap>
+  );
 };
 
 export default SideBar;
@@ -25,5 +36,11 @@ const S = {
       width: ${sideBarWidth.mobile};
       top: ${navBarHeight.mobile};
     }
+  `,
+
+  AddGroup: styled.div`
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
   `,
 };


### PR DESCRIPTION
## 🚀 작업 내용
- 로비 페이지에서 내 정보 클릭하면 모달 뜨게 적용했습니다.
- nav바에서 프로필 클릭하면 모달 뜨게 적용했습니다.
- 그룹 홈 페이지에서  회의 예정, 회의 생성, 그룹 관리를 클릭하면 모달 뜨게 적용했습니다.

## 📝 참고 사항
- 부모 스타일이 적용되어서 스타일을 수정해야 할 꺼 같습니다.

## 🖼️ 스크린샷
![스크린샷 2024-05-29 182518](https://github.com/part4-project/project-front/assets/55544307/7e4fd592-03da-4eac-ad9f-73cb7eadc848)

## 🚨 관련 이슈
- #7