### PR TITLE
그룹 홈 ui 수정

### DIFF
--- a/src/pages/group-home/components/group-home-header.tsx
+++ b/src/pages/group-home/components/group-home-header.tsx
@@ -1,0 +1,45 @@
+import arrowRight from '@assets/icons/arrow-left.svg';
+import GroupModal from '@components/modal/group-modal';
+import MeetingModal from '@components/modal/meeting-modal';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+const GroupHomeHeader = () => {
+  const navigate = useNavigate();
+
+  const handleBackButtonClick = () => {
+    navigate('/');
+  };
+
+  return (
+    <S.Container>
+      <S.BackButton onClick={handleBackButtonClick} />
+      <S.ManageButtons>
+        <GroupModal>그룹 관리</GroupModal>
+        <MeetingModal>회의 생성</MeetingModal>
+      </S.ManageButtons>
+    </S.Container>
+  );
+};
+
+export default GroupHomeHeader;
+
+const S = {
+  Container: styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  `,
+
+  BackButton: styled.img.attrs({
+    src: arrowRight,
+  })`
+    width: 20px;
+    cursor: pointer;
+  `,
+
+  ManageButtons: styled.div`
+    display: flex;
+    gap: 20px;
+  `,
+};

--- a/src/pages/group-home/components/group-home-sidebar.tsx
+++ b/src/pages/group-home/components/group-home-sidebar.tsx
@@ -1,7 +1,12 @@
 import { GROUP, GROUP_MEMBER } from '@constants/mockdata';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const GroupHomeSideBar = () => {
+  const navigate = useNavigate();
+  const handleLeaveGroupButtonClick = () => {
+    navigate('/');
+  };
   return (
     <S.Container>
       <S.GroupName>{GROUP.room_name}</S.GroupName>
@@ -15,6 +20,8 @@ const GroupHomeSideBar = () => {
           </S.GroupMemberList>
         ))}
       </S.GroupMemberLists>
+
+      <S.LeaveGroupButton onClick={handleLeaveGroupButtonClick}>그룹 나가기</S.LeaveGroupButton>
     </S.Container>
   );
 };
@@ -26,6 +33,7 @@ const S = {
     background-color: rgba(0, 0, 0, 0.1);
     width: 260px;
     padding: 20px 10px;
+    position: relative;
   `,
 
   GroupName: styled.span`
@@ -51,5 +59,15 @@ const S = {
     padding-left: 10px;
     font-size: 13px;
     color: orange;
+  `,
+
+  LeaveGroupButton: styled.button`
+    background-color: rgba(0, 0, 0, 0.2);
+    width: 100px;
+    height: 40px;
+    border-radius: 6px;
+    position: absolute;
+    bottom: 40px;
+    left: calc(50% - 50px);
   `,
 };

--- a/src/pages/group-home/components/group-home-sidebar.tsx
+++ b/src/pages/group-home/components/group-home-sidebar.tsx
@@ -1,0 +1,55 @@
+import { GROUP, GROUP_MEMBER } from '@constants/mockdata';
+import styled from 'styled-components';
+
+const GroupHomeSideBar = () => {
+  return (
+    <S.Container>
+      <S.GroupName>{GROUP.room_name}</S.GroupName>
+      <S.GroupCode>#{GROUP.code}</S.GroupCode>
+
+      <S.GroupMemberLists>
+        {GROUP_MEMBER.member_list.map((member) => (
+          <S.GroupMemberList>
+            <span>{member.name}</span>
+            {member.is_admin && <S.AdminIcon>그룹장</S.AdminIcon>}
+          </S.GroupMemberList>
+        ))}
+      </S.GroupMemberLists>
+    </S.Container>
+  );
+};
+
+export default GroupHomeSideBar;
+
+const S = {
+  Container: styled.div`
+    background-color: rgba(0, 0, 0, 0.1);
+    width: 260px;
+    padding: 20px 10px;
+  `,
+
+  GroupName: styled.span`
+    font-size: 20px;
+    margin-right: 5px;
+  `,
+
+  GroupCode: styled.span`
+    color: rgba(0, 0, 0, 0.3);
+  `,
+
+  GroupMemberLists: styled.ul`
+    border-top: 1px solid rgba(0, 0, 0, 0.2);
+    margin-top: 20px;
+    padding-top: 20px;
+  `,
+
+  GroupMemberList: styled.li`
+    padding: 10px;
+  `,
+
+  AdminIcon: styled.span`
+    padding-left: 10px;
+    font-size: 13px;
+    color: orange;
+  `,
+};

--- a/src/pages/group-home/components/meeting-notes.tsx
+++ b/src/pages/group-home/components/meeting-notes.tsx
@@ -67,7 +67,12 @@ const MeetingNotes = () => {
 export default MeetingNotes;
 
 const S = {
-  Container: styled.div``,
+  Container: styled.div`
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+  `,
 
   MeetingNotesHeader: styled.div`
     display: flex;
@@ -94,7 +99,6 @@ const S = {
     border: 1px solid rgba(0, 0, 0, 0.2);
     border-radius: 6px;
     padding: 10px;
-    height: 200px;
     overflow-y: auto;
   `,
 

--- a/src/pages/group-home/components/meetings.tsx
+++ b/src/pages/group-home/components/meetings.tsx
@@ -1,4 +1,3 @@
-import MeetingModal from '@components/modal/meeting-modal';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -13,9 +12,7 @@ const Meetings = () => {
     <S.Container>
       <S.Meetings>
         <div onClick={handleMeetingClick}>회의중</div>
-        <MeetingModal>
-          <div>회의 예정</div>
-        </MeetingModal>
+        <div>회의 예정</div>
       </S.Meetings>
     </S.Container>
   );
@@ -36,8 +33,8 @@ const S = {
     div {
       background-color: rgba(0, 0, 0, 0.04);
       border-radius: 6px;
-      width: 500px;
-      height: 340px;
+      width: 400px;
+      aspect-ratio: 1.3/1;
       box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
       display: flex;
       align-items: center;

--- a/src/pages/group-home/index.tsx
+++ b/src/pages/group-home/index.tsx
@@ -1,35 +1,19 @@
-import arrowRight from '@assets/icons/arrow-left.svg';
-import GroupModal from '@components/modal/group-modal';
-import MeetingModal from '@components/modal/meeting-modal';
 import { navBarHeight } from '@styles/subsection-size';
-import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import GroupHomeHeader from './components/group-home-header';
+import GroupHomeSideBar from './components/group-home-sidebar';
 import MeetingNotes from './components/meeting-notes';
 import Meetings from './components/meetings';
 
 const GroupHome = () => {
-  const navigate = useNavigate();
-
-  const handleBackButtonClick = () => {
-    navigate('/');
-  };
-
   return (
     <S.Container>
-      <S.GroupHomeHeader>
-        <S.BackButton onClick={handleBackButtonClick} />
-        <S.ManageButtons>
-          <GroupModal>
-            <div>그룹 관리</div>
-          </GroupModal>
-          <MeetingModal>
-            <div>회의 생성</div>
-          </MeetingModal>
-        </S.ManageButtons>
-      </S.GroupHomeHeader>
-
-      <Meetings />
-      <MeetingNotes />
+      <GroupHomeSideBar />
+      <S.GroupHomeMain>
+        <GroupHomeHeader />
+        <Meetings />
+        <MeetingNotes />
+      </S.GroupHomeMain>
     </S.Container>
   );
 };
@@ -38,12 +22,22 @@ export default GroupHome;
 
 const S = {
   Container: styled.div`
+    display: flex;
+  `,
+
+  SideBar: styled.div`
+    background-color: rgba(0, 0, 0, 0.1);
+    width: 270px;
+  `,
+
+  GroupHomeMain: styled.div`
+    width: 100%;
+
     height: calc(100vh - ${navBarHeight.desktop});
     padding: 30px;
     overflow: hidden;
     display: flex;
     flex-direction: column;
-
     button {
       background-color: rgba(0, 0, 0, 0.1);
       padding: 10px 15px;
@@ -53,23 +47,5 @@ const S = {
         background-color: rgba(0, 0, 0, 0.14);
       }
     }
-  `,
-
-  GroupHomeHeader: styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  `,
-
-  BackButton: styled.img.attrs({
-    src: arrowRight,
-  })`
-    width: 15px;
-    cursor: pointer;
-  `,
-
-  ManageButtons: styled.div`
-    display: flex;
-    gap: 20px;
   `,
 };

--- a/src/pages/group-home/index.tsx
+++ b/src/pages/group-home/index.tsx
@@ -1,6 +1,7 @@
 import arrowRight from '@assets/icons/arrow-left.svg';
 import GroupModal from '@components/modal/group-modal';
 import MeetingModal from '@components/modal/meeting-modal';
+import { navBarHeight } from '@styles/subsection-size';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import MeetingNotes from './components/meeting-notes';
@@ -37,8 +38,12 @@ export default GroupHome;
 
 const S = {
   Container: styled.div`
-    /* margin-left: 360px; */
+    height: calc(100vh - ${navBarHeight.desktop});
     padding: 30px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+
     button {
       background-color: rgba(0, 0, 0, 0.1);
       padding: 10px 15px;


### PR DESCRIPTION
## 🚀 작업 내용

- 중앙 섹션 스크롤 생기지 않도록 디자인 변경

- 회의록 리스트 화면 크기에 맞게 높이 변하도록 설정
- `GroupHomeHeader` 컴포넌트 분리
- `GroupHomeSideBar` 컴포넌트 추가

## 📝 참고 사항

- `GroupHomeSideBar`에 있는 데이터들은 원래 `SideBar`에서 그룹 클릭 시 prop으로 받아와야 하지만 일단은 임시로 mock데이터에 바로 접근해서 보여주었습니다.

## 🖼️ 스크린샷
<img width="1467" alt="스크린샷 2024-05-30 오후 5 23 56" src="https://github.com/part4-project/effi_frontend/assets/75316998/cff94298-5c99-4374-9972-0cca801414ae">



## 🚨 관련 이슈

- #30 
