### PR TITLE
feat: 로비페이지 UI 수정 및 calendar, schedule-list 연동

### DIFF
--- a/src/constants/mockdata.ts
+++ b/src/constants/mockdata.ts
@@ -74,3 +74,48 @@ export const TOPIC = {
     },
   ],
 };
+
+export const MY_SCHEDULE_LIST = [
+  {
+    id: 1,
+    group: '그룹1',
+    start_date: '24-05-30 12:00',
+    expected_end_date: '24-05-30 14:00',
+    title: '프론트회의',
+  },
+  {
+    id: 2,
+    group: '그룹2',
+    start_date: '24-05-30 15:00',
+    expected_end_date: '24-05-30 16:00',
+    title: '백엔드회의',
+  },
+  {
+    id: 3,
+    group: '그룹3',
+    start_date: '24-05-30 17:00',
+    expected_end_date: '24-05-30 20:00',
+    title: '전체회의',
+  },
+  {
+    id: 4,
+    group: '그룹4',
+    start_date: '24-05-31 16:00',
+    expected_end_date: '24-05-31 18:00',
+    title: 'webRTC 자료 공유',
+  },
+  {
+    id: 5,
+    group: '그룹5',
+    start_date: '24-06-01 16:00',
+    expected_end_date: '24-06-01 18:00',
+    title: 'webSocket 자료 공유',
+  },
+  {
+    id: 6,
+    group: '그룹6',
+    start_date: '24-06-01 20:00',
+    expected_end_date: '24-06-01 22:00',
+    title: 'API 회의',
+  },
+];

--- a/src/pages/lobby/components/my-calendar.tsx
+++ b/src/pages/lobby/components/my-calendar.tsx
@@ -1,17 +1,37 @@
-import { useState } from 'react';
+import { MY_SCHEDULE_LIST } from '@constants/mockdata';
 import Calendar from 'react-calendar';
 import styled from 'styled-components';
+import { CalendarValue } from '../types/type';
+import { formatDate } from '../utils/format-date';
 import 'react-calendar/dist/Calendar.css';
 
-type ValuePiece = Date | null;
-type Value = ValuePiece | [ValuePiece, ValuePiece];
+interface MyCalendarProps {
+  DateValue: CalendarValue;
+  onChangeDate: (value: CalendarValue) => void;
+}
 
-const MyCalendar = () => {
-  const [selectedDate, setSelectedDate] = useState<Value>(new Date());
+const MyCalendar = ({ DateValue, onChangeDate }: MyCalendarProps) => {
   return (
     <S.MyCalender>
-      <Calendar onChange={setSelectedDate} value={selectedDate} />
-      <p>선택된 데이트 객체 {selectedDate?.toLocaleString()}</p>
+      <Calendar
+        calendarType="gregory" // 일 월 화 ~ 토 순서로 요일 정렬
+        // showNeighboringMonth={false} // 인접한 이전,이후 월에 해당하는 일자 숨기기
+        formatDay={(_, date) => date.toLocaleString('en', { day: 'numeric' })} // 일자 숫자만 보이게
+        next2Label={null} // 이후년도 이동 화살표 제거
+        prev2Label={null} // 이전년도 이동 화살표 제거
+        onChange={onChangeDate}
+        value={DateValue}
+        tileContent={({ date, view }) => {
+          const html = [];
+          // if (view === 'month' && date.getMonth() === today.getMonth() && date.getDate() === today.getDate()) {
+          //   html.push(<S.StyledToday key={'today'}>오늘</S.StyledToday>);
+          // }
+          if (MY_SCHEDULE_LIST.find(({ start_date }) => start_date.startsWith(formatDate(date)))) {
+            html.push(<S.StyledDot key={date.toLocaleString()} />);
+          }
+          return <>{html}</>;
+        }}
+      />
     </S.MyCalender>
   );
 };
@@ -20,8 +40,73 @@ export default MyCalendar;
 
 const S = {
   MyCalender: styled.div`
-    width: 544px;
+    width: 100%;
     height: 400px;
     border: 1px solid black;
+
+    // 전체 캘린더
+    .react-calendar {
+      width: 100%;
+      height: 100%;
+    }
+
+    // 상단 요일 부분
+    .react-calendar__month-view__weekdays abbr {
+      text-decoration: none;
+      font-weight: 800;
+      font-size: 16px;
+    }
+    // 오늘 날짜 표시 커스텀
+    .react-calendar__tile--now {
+      background-color: #ffb6c1;
+      border-radius: 16px;
+    }
+
+    // 상단 년월 커스텀
+    .react-calendar__navigation__label > span {
+      font-size: 16px;
+      font-weight: 800;
+    }
+    // 일자 타일 커스텀
+    .react-calendar__tile {
+      font-size: 16px;
+      padding: 15px;
+      position: relative;
+    }
+
+    // 날짜 hover, focus 시 타일
+    .react-calendar__tile:enabled:hover,
+    .react-calendar__tile:enabled:focus {
+      background-color: #d3d3d3 !important;
+      border-radius: 16px;
+    }
+
+    // 선택된 날짜 타일
+    .react-calendar__tile--active {
+      background-color: #d3d3d3 !important;
+      border-radius: 16px;
+    }
+  `,
+
+  // 오늘 날짜에 '오늘' 텍스트 스타일
+  // StyledToday: styled.div`
+  //   font-size: 12px;
+  //   color: red;
+  //   position: absolute;
+  //   top: 60%;
+  //   left: 50%;
+  //   transform: translateX(-50%);
+  // `,
+
+  // 일정이 있는 일자에 점 표시 스타일
+  StyledDot: styled.div`
+    background-color: blue;
+    border-radius: 50%;
+    width: 5px;
+    height: 5px;
+    position: absolute;
+    top: 70%;
+    left: 50%;
+    transform: translateX(-50%);
   `,
 };

--- a/src/pages/lobby/components/my-schedule-list.tsx
+++ b/src/pages/lobby/components/my-schedule-list.tsx
@@ -1,14 +1,37 @@
+import { MY_SCHEDULE_LIST } from '@constants/mockdata';
 import styled from 'styled-components';
+import { CalendarValue } from '../types/type';
+import { formatDate } from '../utils/format-date';
 
-const MyScheduleList = () => {
-  return <S.MyScheduleList>my-schedule-list</S.MyScheduleList>;
+interface MyScheduleListProps {
+  selectedDate: CalendarValue;
+}
+
+const MyScheduleList = ({ selectedDate }: MyScheduleListProps) => {
+  const todaySchedule = MY_SCHEDULE_LIST.filter(({ start_date }) => start_date.startsWith(formatDate(selectedDate)));
+
+  return (
+    <S.MyScheduleList>
+      <h2>Schedule List</h2>
+      <ul>
+        {todaySchedule.map((scheduleItem) => (
+          <li key={scheduleItem.id}>
+            <div>Title: {scheduleItem.title}</div>
+            <div>Group: {scheduleItem.group}</div>
+            <div>Start Date: {scheduleItem.start_date}</div>
+            <div>Expected End Date: {scheduleItem.expected_end_date}</div>
+          </li>
+        ))}
+      </ul>
+    </S.MyScheduleList>
+  );
 };
 
 export default MyScheduleList;
 
 const S = {
   MyScheduleList: styled.div`
-    width: 544px;
+    width: 100%;
     height: 470px;
     border: 1px solid black;
   `,

--- a/src/pages/lobby/index.tsx
+++ b/src/pages/lobby/index.tsx
@@ -1,11 +1,15 @@
+import { useState } from 'react';
 import UserInfoModal from '@components/modal/user-info-modal';
 import styled from 'styled-components';
 import DropdownButton from './components/dropdown-button';
 import MyCalendar from './components/my-calendar';
 import MyScheduleList from './components/my-schedule-list';
 import QuickButton from './components/quick-button';
+import { CalendarValue } from './types/type';
 
 const Lobby = () => {
+  const today = new Date();
+  const [selectedDate, setSelectedDate] = useState<CalendarValue>(today);
   return (
     <S.LobbyPageWrapper>
       <S.QuickButtonBox>
@@ -15,8 +19,8 @@ const Lobby = () => {
         </UserInfoModal>
       </S.QuickButtonBox>
       <S.MyScheduleBox>
-        <MyCalendar />
-        <MyScheduleList />
+        <MyCalendar DateValue={selectedDate} onChangeDate={setSelectedDate} />
+        <MyScheduleList selectedDate={selectedDate} />
       </S.MyScheduleBox>
     </S.LobbyPageWrapper>
   );
@@ -26,20 +30,21 @@ export default Lobby;
 
 const S = {
   LobbyPageWrapper: styled.div`
+    width: 100%;
     border: 1px solid black;
-    /* margin: 76px 0 0 360px; // nav, side 가정 */
     padding: 20px;
     display: flex;
   `,
   QuickButtonBox: styled.div`
+    width: 70%;
     display: flex;
     justify-content: center;
     align-items: center;
     gap: 50px;
-    flex-grow: 3;
     border: 1px solid black;
   `,
   MyScheduleBox: styled.div`
+    width: 30%;
     display: flex;
     flex-direction: column;
     gap: 10px;

--- a/src/pages/lobby/types/type.ts
+++ b/src/pages/lobby/types/type.ts
@@ -1,0 +1,2 @@
+type CalendarValuePiece = Date | null;
+export type CalendarValue = CalendarValuePiece | [CalendarValuePiece, CalendarValuePiece];

--- a/src/pages/lobby/utils/format-date.ts
+++ b/src/pages/lobby/utils/format-date.ts
@@ -1,0 +1,11 @@
+import { CalendarValue } from '../types/type';
+
+export const formatDate = (date: CalendarValue) => {
+  if (date instanceof Date) {
+    const year = String(date.getFullYear()).slice(-2);
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+  throw Error('INVALID DATE');
+};


### PR DESCRIPTION

## 🚀 작업 내용

- 로비 페이지 내 컴포넌트 width 값을 고정값에서 %로 변경하였습니다.
-  내 일정 스케쥴 mockData를 추가하였습니다.
- react-calendar와 스케쥴 일정을 연동하여 예약된 회의가 있는 일자에 도트(점)표기가 되도록 커스텀 하였습니다.
- 선택된 Date는 calendar 와 schedule-list 두 곳에서 사용되어 관리 state를 로비페이지 상단으로 임시이동 하였습니다.
- 도트 표기된 일자를 선택하면 하단 schedule-list에 상세 일정이 나타나도록 임시로 연동하였습니다.
- react-calendar 디자인을 시험삼아 몇 군데 커스텀하였습니다. 자세한 커스텀은 추후 디자인이 나오면 적용시키면 될 것 같습니다.
- 공통으로 사용되는 type이 발생되어 types 폴더를 생성하여 모듈화하였습니다.

## 📝 참고 사항

- 현재 일정 연동 상태의 상세 로직은 API가 확정되면 바뀌게 될 것 같아 확인용으로만 보면 될 것 같습니다.
- 컴포넌트의 props는 모두 interface를 사용하고 있지만, 함수에 들어가는 단일 지정 타입이나 union 타입 적용시에는 interface 말고 type을 사용하였는데 이런 경우에는 혼용하는게 어떤지 의견 주시면 감사합니당.

## 🖼️ 스크린샷

https://github.com/part4-project/effi_frontend/assets/128225030/362e164f-721f-4081-b046-9656623062ef




## 🚨 관련 이슈

- 
