### PR TITLE
feat: meeting-room 목데이터 적용 및 ui 수정

### DIFF
--- a/src/pages/meeting-room/components/room-camera.tsx
+++ b/src/pages/meeting-room/components/room-camera.tsx
@@ -13,10 +13,8 @@ export default RoomCamera;
 
 const S = {
   Container: styled.video<{ $cameraCount: number }>`
-    flex: 1;
     aspect-ratio: 16 / 9;
-    max-width: ${({ $cameraCount }) => CalculateCameraWidth($cameraCount)};
-    min-width: calc(30%);
+    width: ${({ $cameraCount }) => CalculateCameraWidth($cameraCount)};
     border-radius: 10px;
     background: #f1f1f1;
   `,

--- a/src/pages/meeting-room/components/title.tsx
+++ b/src/pages/meeting-room/components/title.tsx
@@ -2,13 +2,17 @@ import arrowLeft from '@assets/icons/arrow-left.svg';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-const Title = () => {
+interface TitleProps {
+  title: string;
+}
+
+const Title = ({ title }: TitleProps) => {
   return (
     <S.Container>
       <S.Link as={Link} to="/">
         <img src={arrowLeft} alt="뒤로가기" />
       </S.Link>
-      <S.Title>제목</S.Title>
+      <S.Title>{title}</S.Title>
     </S.Container>
   );
 };
@@ -29,9 +33,12 @@ const S = {
     justify-content: center;
   `,
   Title: styled.div`
-    width: 149px;
+    width: 180px;
     height: 40px;
     opacity: 0.4;
     background: #c1c1c1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   `,
 };

--- a/src/pages/meeting-room/components/topics.tsx
+++ b/src/pages/meeting-room/components/topics.tsx
@@ -1,7 +1,26 @@
 import styled from 'styled-components';
 
-const Topics = () => {
-  return <S.Container>안건</S.Container>;
+type TopicListType = {
+  id: number;
+  topic_name: string;
+  is_completed: boolean;
+};
+
+interface TopicsProps {
+  topicList: TopicListType[];
+}
+
+const Topics = ({ topicList }: TopicsProps) => {
+  return (
+    <S.Container>
+      {topicList.map((topic) => (
+        <S.TopicItem key={topic.id}>
+          <input type="checkbox" id={topic.topic_name} name={topic.topic_name} defaultChecked={topic.is_completed} />
+          <label htmlFor={topic.topic_name}>{topic.topic_name}</label>
+        </S.TopicItem>
+      ))}
+    </S.Container>
+  );
 };
 
 export default Topics;
@@ -13,5 +32,13 @@ const S = {
     border-radius: 10px;
     background: #fafafa;
     box-shadow: 0px 4px 15.7px 0px rgba(0, 0, 0, 0.25);
+  `,
+  TopicItem: styled.div`
+    display: flex;
+    align-items: center;
+    margin: 16px;
+    input {
+      margin-right: 8px;
+    }
   `,
 };

--- a/src/pages/meeting-room/index.tsx
+++ b/src/pages/meeting-room/index.tsx
@@ -61,7 +61,9 @@ const S = {
   `,
   LeftSection: styled.div`
     width: 1491px;
+    position: relative;
     display: flex;
+    align-items: center;
     flex-direction: column;
     &:hover {
       & > div:first-child,
@@ -75,20 +77,21 @@ const S = {
     display: flex;
     justify-content: space-between;
     width: 100%;
-    padding: 43px 47px 59px 53px;
+    padding: 40px;
     visibility: hidden;
     opacity: 0;
     transition:
       visibility 0s,
       opacity 0.3s linear;
+    position: absolute;
+    top: 0;
   `,
   RoomCameraContainer: styled.div`
     display: flex;
     align-items: center;
     width: 100%;
     height: 100%;
-    padding-left: 101px;
-    padding-right: 47px;
+    padding: 40px;
   `,
   RoomCameraBox: styled.div`
     display: flex;
@@ -102,18 +105,20 @@ const S = {
     justify-content: center;
     align-items: center;
     gap: 4px;
-    padding: 59px 47px 48px 101px;
+    padding: 40px;
     visibility: hidden;
     opacity: 0;
     transition:
       visibility 0s,
       opacity 0.3s linear;
+    position: absolute;
+    bottom: 0;
   `,
   RightSection: styled.div`
     width: 429px;
     display: flex;
     flex-direction: column;
     gap: 35px;
-    margin: 30px 21px 24px 0;
+    margin: 30px;
   `,
 };

--- a/src/pages/meeting-room/index.tsx
+++ b/src/pages/meeting-room/index.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { MEETING_ROOM, TOPIC } from '@constants/mockdata';
 import styled from 'styled-components';
 import Chatting from './components/chatting';
 import RoomButton from './components/room-button';
@@ -10,17 +12,30 @@ const BUTTONS = [{ type: '카메라' }, { type: '마이크' }, { type: '나가�
 const CAMERAS = [{ user: 1 }, { user: 2 }, { user: 3 }, { user: 4 }, { user: 5 }];
 
 const MeetingRoom = () => {
+  const [cameras, setCameras] = useState(CAMERAS);
+
+  const handleAddCamButtonClick = () => {
+    setCameras([...cameras, { user: 1 }]);
+  };
+
+  const handleRemoveCamButtonClick = () => {
+    setCameras(cameras.slice(0, cameras.length - 1));
+  };
   return (
     <S.Container>
       <S.LeftSection>
         <S.Nav>
-          <Title />
+          <Title title={MEETING_ROOM.title} />
+          <button onClick={handleAddCamButtonClick}>AddCam +</button>
+          <button onClick={handleRemoveCamButtonClick}>RemoveCam -</button>
           <Timer />
         </S.Nav>
         <S.RoomCameraContainer>
-          {CAMERAS.map((_, idx) => (
-            <RoomCamera key={idx} cameraCount={CAMERAS.length} />
-          ))}
+          <S.RoomCameraBox>
+            {cameras.map((_, idx) => (
+              <RoomCamera key={idx} cameraCount={cameras.length} />
+            ))}
+          </S.RoomCameraBox>
         </S.RoomCameraContainer>
         <S.RoomButtonContainer>
           {BUTTONS.map((BUTTON, idx) => (
@@ -29,7 +44,7 @@ const MeetingRoom = () => {
         </S.RoomButtonContainer>
       </S.LeftSection>
       <S.RightSection>
-        <Topics />
+        <Topics topicList={TOPIC.topic_list} />
         <Chatting />
       </S.RightSection>
     </S.Container>
@@ -69,14 +84,18 @@ const S = {
   `,
   RoomCameraContainer: styled.div`
     display: flex;
-    flex-wrap: wrap-reverse;
-    justify-content: center;
     align-items: center;
     width: 100%;
     height: 100%;
-    gap: 30px;
     padding-left: 101px;
     padding-right: 47px;
+  `,
+  RoomCameraBox: styled.div`
+    display: flex;
+    flex-wrap: wrap-reverse;
+    justify-content: center;
+    width: 100%;
+    gap: 10px;
   `,
   RoomButtonContainer: styled.div`
     display: flex;

--- a/src/pages/meeting-room/utils/calculate-camera-width.ts
+++ b/src/pages/meeting-room/utils/calculate-camera-width.ts
@@ -1,11 +1,25 @@
 const CalculateCameraWidth = (cameraCount: number) => {
-  if (cameraCount === 1) {
-    return 'calc(70%)';
-  } else if (cameraCount === 2) {
-    return 'calc(50%)';
-  } else if (cameraCount >= 3) {
-    return 'calc(30%)';
+  let width = '';
+  switch (cameraCount) {
+    case 1:
+      width = 'calc(70% - 20px)';
+      break;
+    case 2:
+      width = 'calc(50% - 20px)';
+      break;
+    case 3:
+    case 4: // 3 또는 4인 경우
+      width = 'calc(40% - 20px)';
+      break;
+    case 5:
+    case 6: // 5 또는 6인 경우
+      width = 'calc(33.3% - 20px)';
+      break;
+    default:
+      width = 'calc(25% - 20px)'; // 7 이상인 경우
+      break;
   }
+  return width;
 };
 
 export default CalculateCameraWidth;


### PR DESCRIPTION
## 🚀 작업 내용
- 회의실 목데이터 적용 
- 룸 카메라 크기 수정 했습니다 (카메라 UI 테스트용 카메라 추가 삭제 버튼 추가 해놓았습니다.)

## 📝 참고 사항

- 카메라 크기는 일단 좀 더 크게 맞추긴 했는데 더 나은 방법이 있는지 찾아보겠습니다
- 목데이터 적용 했습니다.(회의실 이름, 토픽 체크 리스트)

## 🖼️ 스크린샷
![image](https://github.com/part4-project/effi_frontend/assets/107683008/54785a5c-47b7-43eb-8b17-bb2466ac57a7)
![image](https://github.com/part4-project/effi_frontend/assets/107683008/73505c5e-119d-475a-8c5c-3d4714225ade)
![image](https://github.com/part4-project/effi_frontend/assets/107683008/1aed95fa-4b32-4f44-b486-e689c5cb446e)
![image](https://github.com/part4-project/effi_frontend/assets/107683008/c37dd4b1-e230-45d6-b906-a67dcdfa375f)




## 🚨 관련 이슈

