### PR TITLE
그룹관리 모달 디자인 적용 및 모달하단버튼 공용컴포넌트로 분리

### DIFF
--- a/src/components/modal/modal-button.tsx
+++ b/src/components/modal/modal-button.tsx
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+
+interface ModalButtonProp {
+  children: React.ReactNode;
+  type: 'primary' | 'secondary' | 'disable';
+}
+
+const ModalButton = ({ children, type }: ModalButtonProp) => {
+  return <S.Button $type={type}>{children}</S.Button>;
+};
+
+export default ModalButton;
+
+const S = {
+  Button: styled.button<{ $type: 'primary' | 'secondary' | 'disable' }>`
+    width: 250px;
+    border-radius: 30px;
+    padding: 15px 0;
+    font-size: 20px;
+    font-weight: 700;
+    text-align: center;
+    ${({ $type }) => {
+      switch ($type) {
+        case 'primary':
+          return `
+            color: var(--white);
+            background-color: var(--blue01);
+            border: 1px solid transparent;
+            `;
+        case 'secondary':
+          return `
+            background-color: var(--white);
+            color: var(--blue01);
+            border: 1px solid var(--blue01);
+          `;
+        case 'disable':
+          return `
+            color: var(--white);
+            background-color: var(--gray01, #9E9E9E);
+            border: 1px solid transparent;
+            `;
+      }
+    }};
+  `,
+};

--- a/src/pages/group-home/components/group-modal/group-invite.tsx
+++ b/src/pages/group-home/components/group-modal/group-invite.tsx
@@ -3,12 +3,10 @@ import styled from 'styled-components';
 const GroupInvite = () => {
   return (
     <S.InviteWrap>
-      <S.EmailLabel htmlFor="email">그룹초대하기</S.EmailLabel>
+      <S.EmailLabel htmlFor="email">그룹 초대하기</S.EmailLabel>
       <S.EmailInputBox>
-        <S.EmailInput id="email" name="email" type="text" placeholder="이메일을 입력해주세요" />
-        <S.EmailSendBtnBox>
-          <S.EmailSendBtn>전송하기</S.EmailSendBtn>
-        </S.EmailSendBtnBox>
+        <S.EmailInput id="email" name="email" type="text" placeholder="이메일을 입력해주세요!" />
+        <S.EmailSendBtn>초대하기</S.EmailSendBtn>
       </S.EmailInputBox>
     </S.InviteWrap>
   );
@@ -20,23 +18,37 @@ const S = {
   InviteWrap: styled.div`
     width: 100%;
   `,
-  EmailLabel: styled.label``,
+  EmailLabel: styled.label`
+    display: inline-block;
+    color: #404040;
+    font-size: 18px;
+    font-weight: 700;
+    margin-bottom: 6px;
+  `,
   EmailInputBox: styled.div`
-    background-color: #c1c1c1;
-    padding: 12px 24px;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    border-radius: 8px;
+    gap: 10px;
   `,
   EmailInput: styled.input`
-    flex-basis: 50%;
-    background-color: transparent;
+    flex: 1 1 auto;
+    background-color: #fafafa;
+    border: 1px solid #9e9e9e;
+    border-radius: 5px;
+    padding: 12px 15px;
+    &::placeholder {
+      color: #bdbdbd;
+      font-size: 14px;
+      font-weight: 500;
+    }
   `,
-  EmailSendBtnBox: styled.div`
-    padding: 8px 12px;
-    border-radius: 8px;
-    background-color: #cccccc;
+  EmailSendBtn: styled.button`
+    padding: 12px 30px;
+    border-radius: 5px;
+    background-color: var(--blue02);
+    color: var(--blue01);
+    font-size: 14px;
+    font-weight: 700;
   `,
-  EmailSendBtn: styled.button``,
 };

--- a/src/pages/group-home/components/group-modal/group-member-info.tsx
+++ b/src/pages/group-home/components/group-modal/group-member-info.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 
 interface GroupMemberInfoProp {
@@ -7,15 +8,22 @@ interface GroupMemberInfoProp {
 }
 
 const GroupMemberInfo: React.FC<GroupMemberInfoProp> = ({ name }) => {
+  const [isExport, setIsExport] = useState<boolean>(false);
+  const exportName = isExport ? '내보내기 취소' : '내보내기';
+
+  const handleExportClick = () => {
+    setIsExport((currentExport) => !currentExport);
+  };
+
   return (
     <S.MemberInfoWrap>
       <S.MemberInfo>
-        <S.MemberName>{name}</S.MemberName>
+        <S.MemberName $isExport={isExport}>{name}</S.MemberName>
         <S.MemberEmail>이메일</S.MemberEmail>
       </S.MemberInfo>
-      <S.MemberExileBtnBox>
-        <S.MemberExileBtn>내보내기</S.MemberExileBtn>
-      </S.MemberExileBtnBox>
+      <S.MemberExportBtn $isExport={isExport} onClick={handleExportClick}>
+        {exportName}
+      </S.MemberExportBtn>
     </S.MemberInfoWrap>
   );
 };
@@ -27,22 +35,32 @@ const S = {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    background-color: #c1c1c1;
-    border-radius: 8px;
+    padding-block: 8px;
+    border-bottom: 1px solid #bdbdbd;
+    &:last-child {
+      border-bottom: 0;
+    }
   `,
   MemberInfo: styled.div`
     display: flex;
     gap: 4px;
     align-items: end;
   `,
-  MemberName: styled.div``,
+  MemberName: styled.div<{ $isExport: boolean }>`
+    color: ${({ $isExport }) => ($isExport ? '#C9C9C9' : '#9e9e9e')};
+    font-size: 14px;
+    font-weight: 500;
+  `,
   MemberEmail: styled.div`
     font-size: 10px;
   `,
-  MemberExileBtnBox: styled.div`
-    padding: 8px 12px;
-    border-radius: 8px;
-    background-color: #cccccc;
+  MemberExportBtn: styled.button<{ $isExport: boolean }>`
+    padding: 10px;
+    border-radius: 5px;
+    background-color: ${({ $isExport }) => ($isExport ? `var(--white)` : `var(--blue02)`)};
+    border: ${({ $isExport }) => ($isExport ? `1px solid var(--blue02)` : `1px solid transparent`)};
+    color: var(--blue01);
+    font-size: 12px;
+    font-weight: 700;
   `,
-  MemberExileBtn: styled.button``,
 };

--- a/src/pages/group-home/components/group-modal/group-member-list.tsx
+++ b/src/pages/group-home/components/group-modal/group-member-list.tsx
@@ -21,13 +21,17 @@ const S = {
   MemberListWrap: styled.div`
     width: 100%;
   `,
-  MemberListTitle: styled.p``,
+  MemberListTitle: styled.p`
+    color: #404040;
+    font-size: 18px;
+    font-weight: 700;
+    margin-bottom: 6px;
+  `,
   MemberListBox: styled.div`
-    padding: 24px;
-    background-color: #c2c2c2;
-    border-radius: 8px;
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    padding-right: 14px;
+    overflow-y: auto;
+    max-height: 17vh;
   `,
 };

--- a/src/pages/group-home/components/group-modal/group-modal.tsx
+++ b/src/pages/group-home/components/group-modal/group-modal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
-import closeBtn from '@assets/icons/close-btn.svg';
 import Modal from '@components/modal/modal';
+import ModalButton from '@components/modal/modal-button';
+import ModalHeader from '@components/modal/modal-header';
 import styled from 'styled-components';
 import GroupInvite from './group-invite';
 import GroupMemberList from './group-member-list';
@@ -30,21 +31,14 @@ const GroupModal = ({ children }: GroupModalProps) => {
       {children}
       <Modal isOpen={isOpen} onClose={handleModalClose}>
         <S.ModalWrap>
-          <S.ModalHeader>
-            <S.ModalTitle>그룹관리</S.ModalTitle>
-            <S.CloseBtn onClick={handleCloseButtonClick}>
-              <img src={closeBtn} alt="close" />
-            </S.CloseBtn>
-          </S.ModalHeader>
+          <ModalHeader headerTitle="그룹관리" onClose={handleCloseButtonClick} />
           <S.ModalContent>
             <GroupInvite />
             <GroupMemberList />
           </S.ModalContent>
           <S.ModalFooter>
-            <S.GroupDisbandment>그룹해체하기</S.GroupDisbandment>
-            <S.SaveBtnBox>
-              <S.SaveBtn>저장하기</S.SaveBtn>
-            </S.SaveBtnBox>
+            <S.GroupDisbandment>그룹 해체하기</S.GroupDisbandment>
+            <ModalButton type="primary">저장하기</ModalButton>
           </S.ModalFooter>
         </S.ModalWrap>
       </Modal>
@@ -56,13 +50,13 @@ export default GroupModal;
 
 const S = {
   ModalWrap: styled.div`
-    width: 100%;
+    width: 500px;
   `,
   ModalContent: styled.div`
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    padding: 8px;
+    gap: 30px;
+    padding: 40px 20px;
   `,
   ModalHeader: styled.div`
     width: 100%;
@@ -81,11 +75,8 @@ const S = {
   `,
   GroupDisbandment: styled.div`
     cursor: pointer;
+    color: #e74133;
+    font-weight: 500;
+    text-decoration: underline;
   `,
-  SaveBtnBox: styled.div`
-    padding: 8px 12px;
-    border-radius: 8px;
-    background-color: #cccccc;
-  `,
-  SaveBtn: styled.button``,
 };


### PR DESCRIPTION
## 🚀 작업 내용
- 그룹관리 모달 디자인 적용
- 모달 footer에 사용되는 버튼 공용컴포넌트도 분리

## 📝 참고 사항
- 버튼 컴포넌트 반응형은 시안나오면 적용하겠습니다
- 원래 width 100%주고 사용wrap에서 조정하도록 하는데 시안을 보니 사용되는 모든곳에 width값이 같아서 px값으로 넣어놨습니다

### 버튼컴포넌트 사용법!!!
- 버튼type은 `"primary" | "secondary" | "disable"` 3가지로 이름지엇고 UI/UX 가이드를 참고했습니다  #https://brunch.co.kr/@chulhochoiucj0/23
- 버튼 text는 children입니다

## 🖼️ 스크린샷
<img width="582" alt="스크린샷 2024-06-05 오후 6 30 50" src="https://github.com/part4-project/effi_frontend/assets/51107943/548bcc70-91e7-45cb-a4c4-41ccd4e4dd90">

primary버튼
<img width="314" alt="스크린샷 2024-06-05 오후 6 36 46" src="https://github.com/part4-project/effi_frontend/assets/51107943/cd7874f2-cdff-4ed9-a679-5f58484e74cc">

secondary버튼
<img width="295" alt="스크린샷 2024-06-05 오후 6 36 08" src="https://github.com/part4-project/effi_frontend/assets/51107943/d15b5188-f0c5-42b3-9ecd-71cf527be634">

disable버튼
<img width="366" alt="스크린샷 2024-06-05 오후 6 36 01" src="https://github.com/part4-project/effi_frontend/assets/51107943/c01013ae-7a82-46a9-83b4-22e1bccb608c">


## 🚨 관련 이슈
- close #64 
