### PR TITLE
토스트 ui component 및 custom hook 추가

### DIFF
--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+
+interface TToastProps {
+  children: ReactNode;
+  show: boolean;
+}
+
+function Toast({ children, show }: TToastProps) {
+  return <S.Container $show={show}>{children}</S.Container>;
+}
+
+const S = {
+  Container: styled.div<{ $show: boolean }>`
+    position: fixed;
+    left: 50%;
+    top: 70px;
+    transform: translateX(-50%);
+    display: ${({ $show }) => ($show ? 'flex' : 'none')};
+    align-items: center;
+    justify-content: center;
+    background-color: var(--blue05);
+    color: var(--white);
+    opacity: 0.8;
+    width: 364px;
+    height: 50px;
+    z-index: 9999;
+    border-radius: 10px;
+    font-weight: bold;
+  `,
+};
+export default Toast;

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { zIndex } from '@styles/z-index';
 import styled from 'styled-components';
 
 interface TToastProps {
@@ -24,7 +25,7 @@ const S = {
     opacity: 0.8;
     width: 364px;
     height: 50px;
-    z-index: 9999;
+    z-index: ${zIndex.toast};
     border-radius: 10px;
     font-weight: bold;
   `,

--- a/src/components/toast/toaster.tsx
+++ b/src/components/toast/toaster.tsx
@@ -1,0 +1,20 @@
+import Toast from '@components/toast/toast';
+import { useToast } from '@hooks/use-toast';
+
+const Toaster = () => {
+  const { toasts } = useToast();
+
+  return (
+    <>
+      {toasts.map((toast) => {
+        return (
+          <Toast key={toast.id} show={toast.show}>
+            {toast.message}
+          </Toast>
+        );
+      })}
+    </>
+  );
+};
+
+export default Toaster;

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+import Toast from '@components/toast/toast';
+
+const TOAST_REMOVE_DELAY = 3000;
+
+interface Toast {
+  id: string;
+  message: string;
+  show: boolean;
+}
+
+let toasts: Toast[] = [];
+let count = 0;
+
+const genId = () => {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER;
+  return count.toString();
+};
+
+const timeouts = new Map<string, ReturnType<typeof setTimeout>>();
+// eslint-disable-next-line no-unused-vars
+const listeners: Array<(toasts: Toast[]) => void> = [];
+
+const toast = (message: string) => {
+  const id = genId();
+
+  listeners.forEach((listener) => {
+    if (!toasts.find((toast) => toast.id === id)) {
+      toasts = [...toasts, { id, message, show: true }];
+    }
+    listener(toasts);
+
+    const timeout = setTimeout(() => {
+      toasts = toasts.map((toast) => {
+        return toast.id === id ? { ...toast, show: false } : toast;
+      });
+      listener(toasts);
+
+      const maxTimeoutId = !!timeouts.size && [...timeouts.entries()]?.reduce((a, b) => (b[1] > a[1] ? b : a))[0];
+
+      if (maxTimeoutId === id) {
+        toasts = [];
+        timeouts.clear();
+      }
+    }, TOAST_REMOVE_DELAY);
+
+    timeouts.set(id, timeout);
+  });
+};
+
+export const useToast = () => {
+  const [state, setState] = useState(toasts);
+
+  useEffect(() => {
+    listeners.push(setState);
+    return () => {
+      const index = listeners.indexOf(setState);
+      if (index > -1) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, []);
+
+  return {
+    toast,
+    toasts: state,
+  };
+};

--- a/src/pages/Root.tsx
+++ b/src/pages/Root.tsx
@@ -1,3 +1,4 @@
+import Toaster from '@components/toast/toaster';
 import NavBar from '@pages/nav-bar';
 import SideBar from '@pages/side-bar';
 import { device } from '@styles/breakpoints';
@@ -22,6 +23,7 @@ const Root = () => {
       )}
       <GlobalStyle />
       <S.Main $isSubSection={isSubSection}>
+        <Toaster />
         <Outlet />
       </S.Main>
     </>

--- a/src/pages/group-home/components/sidebar/group-name-input.tsx
+++ b/src/pages/group-home/components/sidebar/group-name-input.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import editIcon from '@assets/icons/edit.svg';
 import { GROUP } from '@constants/mockdata';
+import { useToast } from '@hooks/use-toast';
 import styled from 'styled-components';
 
 interface TGroupNameInputProps {
@@ -8,6 +9,7 @@ interface TGroupNameInputProps {
 }
 
 const GroupNameInput = ({ isAdmin }: TGroupNameInputProps) => {
+  const { toast } = useToast();
   const [isEditing, setIsEditing] = useState(false);
   const [isInputValueExist, setIsInputValueExist] = useState(true);
   const [groupName, setGroupName] = useState(GROUP.room_name);
@@ -25,11 +27,11 @@ const GroupNameInput = ({ isAdmin }: TGroupNameInputProps) => {
   const handleEditCompleteButtonClick = useCallback(() => {
     if (groupName.length) {
       setIsEditing(false);
-      // 그룹 이름 변경 api
+      toast('그룹명이 변경되었습니다.');
     } else {
       setIsInputValueExist(false);
     }
-  }, [groupName.length]);
+  }, [groupName.length, toast]);
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -51,6 +53,7 @@ const GroupNameInput = ({ isAdmin }: TGroupNameInputProps) => {
       };
     }
   }, [isEditing, handleEditCompleteButtonClick]);
+
   return (
     <div>
       {isEditing ? (

--- a/src/styles/z-index.ts
+++ b/src/styles/z-index.ts
@@ -1,5 +1,5 @@
 const zIndex = {
-  toast: 9999,
+  toast: 110,
   modal: 100,
   backdrop: 99,
   popOver: 98,

--- a/src/styles/z-index.ts
+++ b/src/styles/z-index.ts
@@ -1,4 +1,5 @@
 const zIndex = {
+  toast: 9999,
   modal: 100,
   backdrop: 99,
   popOver: 98,


### PR DESCRIPTION
## 🚀 작업 내용

- 토스트 전역 컴포넌트 및 커스텀 훅 추가

## 📝 참고 사항

- 토스트는 3초 후 닫힘

- 다른 페이지로 이동해도 3초간 유지되도록 구현
- 애니메이션은 미적용 상태
- 아래와 같이 사용하면 됩니다.
```js
const { toast } = useToast();

const handleCreateButtonClick = () => {
  toast('그룹이 생성되었습니다.');
}

return (
  <div>
    <button onClick={handleCreateButtonClick }>생성</button>
  </div>
)
```

## 🖼️ 스크린샷
- 작동 시 토스트 화면 상단 중앙에 뜸
![K-20240610-172414758](https://github.com/part4-project/effi_frontend/assets/75316998/8a72b478-4549-46f7-ba49-f3a3d010f738)

- 다른 페이지로 이동해도 유지
![K-20240610-172421238](https://github.com/part4-project/effi_frontend/assets/75316998/e213fc24-8c92-47b5-b701-054c3cf77c47)


## 🚨 관련 이슈

- #106 
